### PR TITLE
Create pun command (#97)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.89'
+version = '0.9.90'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/commands/fun/PunCommand.java
+++ b/src/main/java/com/avairebot/commands/fun/PunCommand.java
@@ -1,0 +1,126 @@
+package com.avairebot.commands.fun;
+
+import com.avairebot.AvaIre;
+import com.avairebot.chat.PlaceholderMessage;
+import com.avairebot.commands.CommandMessage;
+import com.avairebot.contracts.commands.Command;
+import com.avairebot.factories.RequestFactory;
+import com.avairebot.requests.Request;
+import com.avairebot.requests.Response;
+import com.avairebot.requests.service.PunService;
+import com.avairebot.utilities.RandomUtil;
+import net.dv8tion.jda.core.entities.User;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class PunCommand extends Command {
+
+    public PunCommand(AvaIre avaire) {
+        super(avaire);
+    }
+
+    @Override
+    public String getName() {
+        return "Pun Command";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Gets a random pun about a random subject, or about provide your own subject to get puns about that instead.\nAll puns are loaded from: [icanhazdadjoke.com](https://icanhazdadjoke.com/)";
+    }
+
+    @Override
+    public List<String> getUsageInstructions() {
+        return Arrays.asList(
+            "`:command` - Gets a random pun",
+            "`:command <query>` - Gets a pun about the given query.");
+    }
+
+    @Override
+    public List<String> getExampleUsage() {
+        return Arrays.asList(
+            "`:command` - Gets a random pun.",
+            "`:command chicken` - Gets a random pun about chickens."
+        );
+    }
+
+    @Override
+    public List<String> getTriggers() {
+        return Arrays.asList("pun", "dadjoke");
+    }
+
+    @Override
+    public List<String> getMiddleware() {
+        return Collections.singletonList("throttle:channel,2,5");
+    }
+
+    @Override
+    public boolean onCommand(CommandMessage context, String[] args) {
+        if (args.length == 0) {
+            return getAndSendSingleJoke(context);
+        }
+
+        makeRequest(context, true)
+            .addParameter("term", String.join(" ", args))
+            .send((Consumer<Response>) response -> {
+                String query = String.join(" ", args).trim();
+                PunService service = (PunService) response.toService(PunService.class);
+
+                if (!service.hasData()) {
+                    context.makeWarning(context.i18n(
+                        "noResultsWithQuery"
+                    )).set("query", query).queue();
+                    return;
+                }
+
+                PunService.Pun pun = (PunService.Pun) RandomUtil.pickRandom(service.getResults());
+
+                sendPun(context, pun.getJoke(), query);
+            });
+
+        return true;
+    }
+
+    private boolean getAndSendSingleJoke(CommandMessage context) {
+        makeRequest(context, false).send((Consumer<Response>) response -> {
+            JSONObject json = new JSONObject(response.toString());
+
+            if (!json.has("joke")) {
+                context.makeWarning(context.i18n("noResults")).queue();
+                return;
+            }
+
+            sendPun(context, json.getString("joke"), null);
+        });
+
+        return true;
+    }
+
+    private Request makeRequest(CommandMessage context, boolean withSearch) {
+        return RequestFactory.makeGET("https://icanhazdadjoke.com/" + (withSearch ? "search" : ""))
+            .addHeader("Accept", "application/json")
+            .addHeader("User-Agent", String.format("AvaIre Bot (ID:%s, GitHub:https://github.com/avaire/avaire)",
+                context.getJDA().getSelfUser().getId()
+            ));
+    }
+
+    private void sendPun(CommandMessage context, String joke, String query) {
+        PlaceholderMessage message = context.makeSuccess(joke)
+            .requestedBy(context.getAuthor());
+
+        if (query != null) {
+            User user = context.getAuthor();
+
+            message.setFooter(String.format("Requested by %s#%s | %s",
+                user.getName(), user.getDiscriminator(),
+                context.i18n("query", query)
+            ), user.getEffectiveAvatarUrl());
+        }
+
+        message.queue();
+    }
+}

--- a/src/main/java/com/avairebot/requests/service/PunService.java
+++ b/src/main/java/com/avairebot/requests/service/PunService.java
@@ -1,0 +1,70 @@
+package com.avairebot.requests.service;
+
+import java.util.List;
+
+public class PunService {
+
+    private List<Pun> results;
+    private int page;
+    private int limit;
+    private int next_page;
+    private int previous_page;
+    private int current_page;
+    private int status;
+    private int total_jokes;
+    private int total_pages;
+
+    public boolean hasData() {
+        return results != null && !results.isEmpty();
+    }
+
+    public int getNextPage() {
+        return next_page;
+    }
+
+    public int getPreviousPage() {
+        return previous_page;
+    }
+
+    public int getCurrentPage() {
+        return current_page;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public int getTotalJokes() {
+        return total_jokes;
+    }
+
+    public int getTotalPages() {
+        return total_pages;
+    }
+
+    public List<Pun> getResults() {
+        return results;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public class Pun {
+
+        private String id;
+        private String joke;
+
+        public String getId() {
+            return id;
+        }
+
+        public String getJoke() {
+            return joke;
+        }
+    }
+}

--- a/src/main/resources/langs/da_DK.yml
+++ b/src/main/resources/langs/da_DK.yml
@@ -52,7 +52,6 @@ administration:
         success: "**:role** rollen er blevet tilføjet til selvtilladelige listen.\nServeren har `:slots` flere selvtilladelige roller pladser til rådighed."
 
     AdministrateExperienceCommand:
-    AdministrateExperienceCommand:
         cantUseForBots: "Du kan ikke tilføje, fjerne, eller nulstille XP for en bot-konti, da de ikke kan få noget XP til at starte med. Vælg venligst en normal bruger, når du bruger denne kommando."
         invalidAmountGiven: "Egenskaben `amount` skal være mellem 1 og {0} for at tilføje eller tage XP fra en bruger."
         aboutToResetEverything: "Du er ved at nulstille XP for alle på hele serveren. Bemærk, at denne handling **KAN IKKE** laves om. Hvis du er sikker på, at du vil fortsætte, skal du køre kommandoen for at nulstille serverne XP helt.\n\n```:command server-reset :token```\nDenne kommando fungerer kun i 60 sekunder, efter den tid token bliver ugyldig og kommandoen skal køres igen for at få et nyt token."
@@ -389,6 +388,12 @@ fun:
         invalidType: 'Ugyldig meme type givet, `{0}` er ikke en gyldig meme type!'
         mustIncludeTopAndBottomText: 'Du skal inkludere "top tekst" og "nederste tekst" argumenterne for at generere en meme.'
         listItem: '`{0}` => `{1}`'
+
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
 
     RandomCatCommand:
         tooManyAttempts: "Der blevet for mange forsøg på kat-API'et, prøv igen om et minut eller spørg en botadministrator om at få en API-nøgle på [meow.senither.com](https://meow.senither.com/) for at tillade flere commands per minut."

--- a/src/main/resources/langs/de_DE.yml
+++ b/src/main/resources/langs/de_DE.yml
@@ -390,11 +390,16 @@ fun:
         mustIncludeTopAndBottomText: 'Du musst den `top text` und `bottom text` Argument angeben, um ein Meme generieren zu können.'
         listItem: '`{0}` => `{1}`'
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "Zu viele Versuche wurden zur Cat API getätigt. Warte eine Minute und versuche es erneut. Andernfalls, kontaktiere einen Bot-Administrator um die API [meow.senither.com](https://meow.senither.com/) zu erhalten, um mehr Anfragen zu ermöglichen."
         notFound: "Ich konnte kein Katzenbild finden! Versuch es doch erneut. Vielleicht siehst du jetzt eins."
         somethingWentWrong: "Etwas Unartiges ist passiert. Kontakiere einen Bot-Administrator, der sich das anschauen kann."
-
 
     ReverseCommand:
         palindrome: 'Du hast ein Palindrom umgekehrt, was hast du erwartet?'

--- a/src/main/resources/langs/en_US.yml
+++ b/src/main/resources/langs/en_US.yml
@@ -389,6 +389,12 @@ fun:
         mustIncludeTopAndBottomText: 'You must include the `top text` and `bottom text` arguments to generate a meme.'
         listItem: '`{0}` => `{1}`'
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "Too many attempts was made to the cat API, try again in a minute, or ask a bot administrator to get an API key at [meow.senither.com](https://meow.senither.com/) to allow for more requests."
         notFound: "I couldn't find any cat pictures D: Try again, maybe they will show up now?"

--- a/src/main/resources/langs/es_ES.yml
+++ b/src/main/resources/langs/es_ES.yml
@@ -390,11 +390,16 @@ fun:
         mustIncludeTopAndBottomText: 'Debes incluir los textos superior e inferior para generar un meme.'
         listItem: '"{0}" => "{1}"'
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "Too many attempts was made to the cat API, try again in a minute, or ask a bot administrator to get an API key at [meow.senither.com](https://meow.senither.com/) to allow for more requests."
         notFound: "I couldn't find any cat picture D: Try again, maybe they will show up now?"
         somethingWentWrong: "Something just went horribly wrong, please tell a bot administrator so they can look into this."
-
 
     ReverseCommand:
         palindrome: 'Le has dado la vuelta a un palíndromo, ¿qué esperabas?'
@@ -650,6 +655,7 @@ music:
         alreadyVoted: '¡Solo puedes votar omitir una vez por canción! Con `:votes` más se omitirá la canción.'
 
 search:
+
     DuckDuckGoCommand:
         nsfwDisabled: "The `Duck Duck GO` command can only be used in NSFW channels, as the search results may return NSFW content."
         searchResults: 'Resultado de búsqueda: {0}'

--- a/src/main/resources/langs/fr_FR.yml
+++ b/src/main/resources/langs/fr_FR.yml
@@ -389,11 +389,16 @@ fun:
         mustIncludeTopAndBottomText: "Tu dois inclure les arguments `top text` et `bottom text` pour générer un meme."
         listItem: "`{0}` => `{1}`"
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "Too many attempts was made to the cat API, try again in a minute, or ask a bot administrator to get an API key at [meow.senither.com](https://meow.senither.com/) to allow for more requests."
         notFound: "I couldn't find any cat picture D: Try again, maybe they will show up now?"
         somethingWentWrong: "Something just went horribly wrong, please tell a bot administrator so they can look into this."
-
 
     ReverseCommand:
         palindrome: "Tu as inversé un palindrome, à quoi t'attendais tu?"

--- a/src/main/resources/langs/hu_HU.yml
+++ b/src/main/resources/langs/hu_HU.yml
@@ -395,11 +395,16 @@ fun:
         mustIncludeTopAndBottomText: 'Szükséges megadnod a `top text` és `bottom text` paramétereket, hogy meme-t generálj.'
         listItem: '`{0}` => `{1}`'
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "Too many attempts was made to the cat API, try again in a minute, or ask a bot administrator to get an API key at [meow.senither.com](https://meow.senither.com/) to allow for more requests."
         notFound: "I couldn't find any cat picture D: Try again, maybe they will show up now?"
         somethingWentWrong: "Something just went horribly wrong, please tell a bot administrator so they can look into this."
-
 
     ReverseCommand:
         palindrome: 'Megfordítottál egy palindrom-ot, mit gondoltál?'

--- a/src/main/resources/langs/it_IT.yml
+++ b/src/main/resources/langs/it_IT.yml
@@ -389,6 +389,12 @@ fun:
         mustIncludeTopAndBottomText: 'È necessario includere gli elementi `top text` e `bottom text` per generare un meme.'
         listItem: '`{0}` => `{1}`'
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "Sono stati effettuati troppi tentativi sull'API `cat`, riprova tra un minuto o chiedi ad un amministratore del bot di ottenere una chiave API su [meow.senither.com](https://meow.senither.com/) per consentire più richieste."
         notFound: "Non sono riuscito a trovare nessuna immagine di gatti D: Prova di nuovo, forse si presenteranno ora?"

--- a/src/main/resources/langs/nl_NL.yml
+++ b/src/main/resources/langs/nl_NL.yml
@@ -306,9 +306,9 @@ administration:
         invalidUserIdGiven: "Ongeldige `user id` is gegeven, de `user id` moet een nummer van 18 karakters of langer zijn."
 
     VoiceKickCommand:
-        mustMentionUser: Je moet een gebruiker noemen die je wil kicken."
+        mustMentionUser: "Je moet een gebruiker noemen die je wil kicken."
         sameOrHigherRole: "Je kan geen mensen kicken met een hogere, of dezelfde rol als jezelf."
-        notConnected: Je kan iemand niet uit een spraak kanaal kicken als ze niet verbonden zijn met een spraak kanaal."
+        notConnected: "Je kan iemand niet uit een spraak kanaal kicken als ze niet verbonden zijn met een spraak kanaal."
         message: "**:target** is gekicked van **:voiceChannel** door :user voor \":reason\""
 
     VoteOptCommand:
@@ -388,6 +388,12 @@ fun:
         invalidType: 'Ongeldig meme type gegeven, `{0}` is geen geldig meme type!'
         mustIncludeTopAndBottomText: 'Je moet de `top text` en `bottom text` arguments toevoegen om een meme te genereren.'
         listItem: '`{0}` => `{1}`'
+
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
 
     RandomCatCommand:
         tooManyAttempts: "Teveel aanvragen naar de Cat API, probeer opnieuw in een minuut, of vraag een bot administrator voor een api key op [meow.senither.com](https://meow.senither.com/) om meer aanvragen toe te staan."
@@ -648,6 +654,7 @@ music:
         alreadyVoted: 'Je mag maar een keer stemmen om een nummer over te slaan per nummer! nog maar `:votes` stemmen nodig om het nummer over te slaan.'
 
 search:
+
     DuckDuckGoCommand:
         nsfwDisabled: "Het `Duck Duck GO` commando kan alleen gebruikt worden in NSFW kanalen, omdat de resultaten NSFW beelden kan bevatten."
         searchResults: 'Zoek resultaat voor: {0}'

--- a/src/main/resources/langs/no_NB.yml
+++ b/src/main/resources/langs/no_NB.yml
@@ -389,6 +389,12 @@ fun:
         mustIncludeTopAndBottomText: 'Du må inkludere `top text` og `bottom text` argumentene for og generere en meme.'
         listItem: '`{0}` => `{1}`'
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "Too many attempts was made to the cat API, try again in a minute, or ask a bot administrator to get an API key at [meow.senither.com](https://meow.senither.com/) to allow for more requests."
         notFound: "I couldn't find any cat picture D: Try again, maybe they will show up now?"
@@ -648,6 +654,7 @@ music:
         alreadyVoted: 'Du kan kun stemme for og hoppeover en gang per sang! `:votes` flere stemmer trengs for og hoppe over sangen.'
 
 search:
+
     DuckDuckGoCommand:
         nsfwDisabled: "The `Duck Duck GO` command can only be used in NSFW channels, as the search results may return NSFW content."
         searchResults: 'Søkeresultat med: {0}'

--- a/src/main/resources/langs/ru_RU.yml
+++ b/src/main/resources/langs/ru_RU.yml
@@ -389,11 +389,16 @@ fun:
         mustIncludeTopAndBottomText: 'Вы должны включить аргументы `Заголовок` и `Нижний текст` чтобы создать мем.'
         listItem: '`{0}` => `{1}`'
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "Too many attempts was made to the cat API, try again in a minute, or ask a bot administrator to get an API key at [meow.senither.com](https://meow.senither.com/) to allow for more requests."
         notFound: "I couldn't find any cat picture D: Try again, maybe they will show up now?"
         somethingWentWrong: "Something just went horribly wrong, please tell a bot administrator so they can look into this."
-
 
     ReverseCommand:
         palindrome: 'Вы полностью изменили палиндром, что Вы ожидали?'
@@ -649,6 +654,7 @@ music:
         alreadyVoted: 'Вы можете проголосовать только один раз за трек! `:votes` необходимо голосов, чтобы пропустить трек.'
 
 search:
+
     DuckDuckGoCommand:
         nsfwDisabled: "The `Duck Duck GO` command can only be used in NSFW channels, as the search results may return NSFW content."
         searchResults: 'Результат поиска для: {0}'

--- a/src/main/resources/langs/zh_SI.yml
+++ b/src/main/resources/langs/zh_SI.yml
@@ -388,6 +388,12 @@ fun:
         mustIncludeTopAndBottomText: '您必须包括 `top text` 和 `bottom text` 生成模因的参数.'
         listItem: '`{0}` => `{1}`'
 
+    PunCommand:
+        title: "Pun list"
+        noResults: ":user I found no puns, you can with a search or, or just try again later."
+        noResultsWithQuery: ":user I found nothing for `:query`"
+        query: "Search query: {0}"
+
     RandomCatCommand:
         tooManyAttempts: "对cat api进行了太多的尝试，一分钟后再试一次，或者要求bot管理员在以下位置获取api密钥： [meow.senither.com](https://meow.senither.com/) 允许更多的请求."
         notFound: "我找不到猫的照片D：再试一次，也许它们现在就会出现？"


### PR DESCRIPTION
* Create a user count command

It returns the number of users in the current guild.

* Create an advice command

It retrieves random advice from an Advice API.

* Revert "Create a user count command"

This reverts commit 8f9c517226fe629efbe9c9abb5f28e759937a1fe.

* Create a pun command

This command connects to the ICanHazDadJoke Api and can either retrieve a random pun or a list of puns based on the search criteria.

* Tidy up the commands

The Advice now doesn't have redundant info. The Pun command now uses a service now and sends a warning if the returned list is empty.

* Update PunCommand.java

Remove another character.

* Update PunCommand.java

The help command should work now and the paginator footer should be perfect finally.

* Advice command disabled to due NSFW

After looking at the api a lot more closely and getting embarrased while testing and reading the advice it returned, I decided to make it sure it only ran in NSFW channels.

* Update nl_NL.yml

Forgot to paste it in this file.

* Hopefully fix all remaining issues

As the advice command's ssl certificate was self-signed and overall problematic, it was disposed of. Camel-case lettering was used in the service request. Brackets were used to mark optional arguments. Lastly hopefully I fixed the Yaml file.

* Fix file formatting

* Rewrite pun command to return one result with query

The requester is also added to the embeds now.

* Add custom user agent according to the API regulations

* Remove new line added to the Chinese language file

* Delete unused travis file

Not sure why this was added to PR?

* Bump version